### PR TITLE
Resolve bug that resulted in multiple db entries for a single fight

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -25,8 +25,8 @@ provider:
   runtime: python3.8
 
 #you can overwrite defaults here
- stage: dev
- region: us-east-1
+# stage: dev
+# region: us-east-1
 
 # you can add statements to the Lambda function's IAM Role here
 #  iam:
@@ -126,14 +126,3 @@ functions:
 #     NewOutput:
 #       Description: "Description for the output"
 #       Value: "Some output value"
-
-plugins:
-  - serverless-python-requirements
-
-custom:
-  pythonRequirements:
-    fileName: requirements.txt
-    dockerizePip: non-linux
-    zip: true
-    layer: true
-    slim: true


### PR DESCRIPTION
## What?
The future_matchups table wasn't configured correctly and was allowing for reentering a fight multiple times in the table. This would cause the ufc-event-predictor webpage to show duplicate fights for a given event.
## Resolution? 
Convert the primary key to a hash of rf + bf + rwins + bwins.