### PR TITLE
Migrate AWS infra from ufc-predictor-aws-infra to the serverless.yaml file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ Scrapy==2.6.1
 numpy==1.22.4
 pendulum==2.1.2
 mysql-connector-python==8.0.29
-Twisted==22.4.0
-

--- a/serverless.yml
+++ b/serverless.yml
@@ -29,22 +29,13 @@ provider:
 # region: us-east-1
 
 # you can add statements to the Lambda function's IAM Role here
-#  iam:
-#    role:
-#      statements:
-#        - Effect: "Allow"
-#          Action:
-#            - "s3:ListBucket"
-#          Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
-#        - Effect: "Allow"
-#          Action:
-#            - "s3:PutObject"
-#          Resource:
-#            Fn::Join:
-#              - ""
-#              - - "arn:aws:s3:::"
-#                - "Ref" : "ServerlessDeploymentBucket"
-              #  - "/*"
+  iam:
+    role:
+      statements:
+        - Effect: "Allow"
+          Action:
+            - "secretsmanager:GetSecretValue"
+          Resource: '*'
 
 # you can define service wide environment variables here
 #  environment:
@@ -115,7 +106,6 @@ functions:
 #    environment:
 #      variable2: value2
 
-# you can add CloudFormation resource templates here
 resources:
  Resources:
   UfcPredictorVpc:
@@ -292,8 +282,3 @@ resources:
           - GroupId
     UpdateReplacePolicy: Delete
     DeletionPolicy: Delete
-Outputs:
-  TestDBEndpoint:
-    Value: !GetAtt 
-      - UfcFightPredictorRdsInstance
-      - Endpoint.Address

--- a/serverless.yml
+++ b/serverless.yml
@@ -116,13 +116,184 @@ functions:
 #      variable2: value2
 
 # you can add CloudFormation resource templates here
-#resources:
-#  Resources:
-#    NewResource:
-#      Type: AWS::S3::Bucket
-#      Properties:
-#        BucketName: my-new-bucket
-#  Outputs:
-#     NewOutput:
-#       Description: "Description for the output"
-#       Value: "Some output value"
+resources:
+ Resources:
+  UfcPredictorVpc:
+    Type: 'AWS::EC2::VPC'
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+      InstanceTenancy: default
+      Tags:
+        - Key: Name
+          Value: ufc-predictor-vpc
+  UfcPublicSubnetA:
+    Type: 'AWS::EC2::Subnet'
+    Properties:
+      VpcId: !Ref UfcPredictorVpc
+      AvailabilityZone: !Select 
+        - 0
+        - !GetAZs ''
+      CidrBlock: 10.0.0.0/17
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: 'subnet-name'
+          Value: UfcPublicSubnetA
+        - Key: 'subnet-type'
+          Value: Public
+        - Key: Name
+          Value: UfcPublicSubnetA
+  UfcPublicSubnetARouteTable:
+    Type: 'AWS::EC2::RouteTable'
+    Properties:
+      VpcId: !Ref UfcPredictorVpc
+      Tags:
+        - Key: Name
+          Value: >-
+            UfcPublicSubnetARouteTable
+  UfcPublicSubnetARouteTableAssociation:
+    Type: 'AWS::EC2::SubnetRouteTableAssociation'
+    Properties:
+      RouteTableId: !Ref UfcPublicSubnetARouteTable
+      SubnetId: !Ref UfcPublicSubnetA
+  UfcPublicSubnetADefaultRoute:
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref UfcPublicSubnetARouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref UfcPredictorVpcInternetGateway
+    DependsOn:
+      - UfcPredictorVpcInternetGateway
+
+  UfcPublicSubnetB:
+    Type: 'AWS::EC2::Subnet'
+    Properties:
+      VpcId: !Ref UfcPredictorVpc
+      AvailabilityZone: !Select 
+        - 1
+        - !GetAZs ''
+      CidrBlock: 10.0.128.0/17
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: 'subnet-name'
+          Value: UfcPublicSubnetB
+        - Key: 'subnet-type'
+          Value: Public
+        - Key: Name
+          Value: UfcPublicSubnetB
+
+  UfcPublicSubnetBRouteTable:
+    Type: 'AWS::EC2::RouteTable'
+    Properties:
+      VpcId: !Ref UfcPredictorVpc
+      Tags:
+        - Key: Name
+          Value: >-
+            UfcPublicSubnetBRouteTable
+   
+  UfcPublicSubnetBRouteTableAssociation:
+    Type: 'AWS::EC2::SubnetRouteTableAssociation'
+    Properties:
+      RouteTableId: !Ref UfcPublicSubnetBRouteTable
+      SubnetId: !Ref UfcPublicSubnetB
+
+  UfcPublicSubnetBDefaultRoute:
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref UfcPublicSubnetBRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref UfcPredictorVpcInternetGateway
+    DependsOn:
+      - UfcPredictorVpcInternetGateway
+   
+  UfcPredictorVpcInternetGateway:
+    Type: 'AWS::EC2::InternetGateway'
+    Properties:
+      Tags:
+        - Key: Name
+          Value: ufc-predictor-aws-infra/ufc-predictor-vpc
+
+  UfcPredictorVpcGatewayAttatchment:
+    Type: 'AWS::EC2::VPCGatewayAttachment'
+    Properties:
+      VpcId: !Ref UfcPredictorVpc
+      InternetGatewayId: !Ref UfcPredictorVpcInternetGateway
+      
+  UfcPredictorRDSSG:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Security group for RDS instance
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow all outbound traffic by default
+          IpProtocol: '-1'
+      SecurityGroupIngress:
+        - CidrIp: 0.0.0.0/0
+          Description: 'from 0.0.0.0/0:3306'
+          FromPort: 3306
+          IpProtocol: tcp
+          ToPort: 3306
+      VpcId: !Ref UfcPredictorVpc
+   
+  UfcPredictorRDSSubnetGroup:
+    Type: 'AWS::RDS::DBSubnetGroup'
+    Properties:
+      DBSubnetGroupDescription: Subnet group for ufcfightpredictortest database
+      SubnetIds:
+        - !Ref UfcPublicSubnetA
+        - !Ref UfcPublicSubnetB
+  UfcPredictorRdsSecret:
+    Type: 'AWS::SecretsManager::Secret'
+    Properties:
+      GenerateSecretString:
+        ExcludeCharacters: ' %+~`#$&*()|[]{}:;<>?!''/@"\'
+        GenerateStringKey: password
+        PasswordLength: 30
+        SecretStringTemplate: '{"username":"mysqlAdmin"}'
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+  
+  UfcPredictorRdsSecretAttachment:
+    Type: 'AWS::SecretsManager::SecretTargetAttachment'
+    Properties:
+      SecretId: !Ref UfcPredictorRdsSecret
+      TargetId: !Ref UfcFightPredictorRdsInstance
+      TargetType: 'AWS::RDS::DBInstance'
+   
+  UfcFightPredictorRdsInstance:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBInstanceClass: db.t3.micro
+      AllocatedStorage: '100'
+      AllowMajorVersionUpgrade: false
+      AutoMinorVersionUpgrade: true
+      BackupRetentionPeriod: 0
+      CopyTagsToSnapshot: true
+      DBName: UfcPredictorRDSDb
+      DBSubnetGroupName: !Ref UfcPredictorRDSSubnetGroup
+      DeleteAutomatedBackups: true
+      DeletionProtection: false
+      Engine: mysql
+      EngineVersion: 8.0.19
+      MasterUsername: mysqlAdmin
+      MasterUserPassword: !Join 
+        - ''
+        - - '{{resolve:secretsmanager:'
+          - !Ref UfcPredictorRdsSecret
+          - ':SecretString:password::}}'
+      MaxAllocatedStorage: 105
+      MultiAZ: false
+      PubliclyAccessible: true
+      StorageType: gp2
+      VPCSecurityGroups:
+        - !GetAtt 
+          - UfcPredictorRDSSG
+          - GroupId
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+Outputs:
+  TestDBEndpoint:
+    Value: !GetAtt 
+      - UfcFightPredictorRdsInstance
+      - Endpoint.Address

--- a/src/scraper/pipelines.py
+++ b/src/scraper/pipelines.py
@@ -8,16 +8,28 @@
 import hashlib
 import mysql.connector
 import logging
+import boto3
+import json
 
 
 class UfcFutureFightScraperPipeline:
     def __init__(self):
         logging.info("initializing UfcFutureFightScraperPipeline")
-        # temp DB creds that will be rotated out!!
-        host = 'uu1744jdr5e80dc.cdxfj1ghajls.us-east-1.rds.amazonaws.com'
-        user = 'mysqlAdmin'
-        password = '5bc,cx^h=H8KbdN3x.mSd95jMmZmwK'
-        database = 'thisisatest'
+        # Create a Secrets Manager client
+        session = boto3.session.Session()
+        client = session.client(
+            service_name='secretsmanager',
+            region_name='us-east-1'
+        )
+        logging.info("Grabbing UfcPredictorRdsSecret secret")
+        secretMap = client.get_secret_value(
+            SecretId="UfcPredictorRdsSecret-extTBzicS2ON", VersionStage="AWSCURRENT")
+        rdsSecret = json.loads(secretMap.get("SecretString"))
+        logging.info("Successfully grabbed AWS secret")
+        host = rdsSecret.get("host")
+        user = rdsSecret.get("username")
+        password = rdsSecret.get("password")
+        database = rdsSecret.get("dbname")
         if host != None and user != None and password != None and database != None:
             self.con = mysql.connector.connect(
                 host=host,


### PR DESCRIPTION
## What?
Migrate all AWS infra CF templates from ufc-predictor-aws-infra to this repo
## Why? 
The ufc-predictor-aws-infra repo serves no point other than housing the AWS infra. It makes more sense to port the generated CF templates to the `resources` section of this repo