### PR TITLE
Refit Model Lambda Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ The future fight scraper scraps data for future UFC events. This data will be fe
 
 The future fight reaper cleans up old UFC fights from the future_matchups database. The lambda function runs every Tuesday at 6:00 UTC
 
+### Refit Model Handler
+
+The lambda function refits the models for ufc-event-predictor. The lambda function runs every Tuesday at 8:00 UTC
+
 ## PLANNED FUNCTIONS
 
 `Previous Event Result Scraper` - Scraps and randomizes the previous UFC event and commits the data to the past_matchups DB table

--- a/serverless.yml
+++ b/serverless.yml
@@ -69,6 +69,13 @@ functions:
       - { Ref: PythonRequirementsLambdaLayer}
     events:
       - schedule: cron(0 6 ? * TUES *)
+  refitModels:
+    handler: src/handlers/refit_models.handler
+    timeout: 180
+    layers:
+      - { Ref: PythonRequirementsLambdaLayer }
+    events:
+      - schedule: cron(0 8 ? * TUES *)
 
 resources:
  Resources:

--- a/src/handlers/refit_models.py
+++ b/src/handlers/refit_models.py
@@ -1,0 +1,21 @@
+import requests
+import boto3
+import logging
+
+
+def handler(event, context):
+    logging.getLogger().setLevel(logging.INFO)
+    logging.info(
+        f"Kicking off {context.function_name} with Lambda Request ID {context.aws_request_id}")
+
+    # setup basic auth for api
+    client = boto3.client('secretsmanager', region_name='us-east-1')
+    secretMap = client.get_secret_value(
+        SecretId="UfcEventPredictorApiSecret0-Z6TyTAY1hN5n", VersionStage="AWSCURRENT")
+    api_key = secretMap.get("SecretString")
+
+    api_url = f"https://api_user:{api_key}@event.ufcpredictor.com/api/refit-models"
+
+    response = requests.get(api_url)
+
+    logging.info(response)


### PR DESCRIPTION
## What?
A lambda function to refit the models for ufc-event-predictor
## Why? 
ufc-event-predictor now saves ML models in memory instead of refitting them every time. This function will hit an API endpoint to refit the models